### PR TITLE
Feat : 모달 데이터 입력 인자 추가, 조건부 오버레이 클릭 이벤트 추가

### DIFF
--- a/src/components/common/modal/ModalController.tsx
+++ b/src/components/common/modal/ModalController.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useModalStore } from "@/stores/modalStore";
-import React, { ReactNode } from "react";
+import React from "react";
 import { useStore } from "zustand";
 import Modal from "./Modal";
 import ModalTemp from "./modal-contents/ModalTemp";
@@ -11,7 +11,8 @@ interface ImodalDatas {
   type: TmodalType;
   title: string;
   size: TModalSize;
-  component: ReactNode;
+  overlayClose: boolean;
+  component: React.ComponentType<any>;
 }
 
 const modalDatas: ImodalDatas[] = [
@@ -19,12 +20,13 @@ const modalDatas: ImodalDatas[] = [
     type: "temp",
     title: "모달 테스트",
     size: "medium",
-    component: <ModalTemp />,
-  },
+    overlayClose: true,
+    component: ModalTemp,
+  }
 ];
 
 const ModalController = () => {
-  const { isOpen, closeModal, modalType } = useStore(useModalStore);
+  const { isOpen, closeModal, modalType, props } = useStore(useModalStore);
 
   if (!isOpen) return null;
 
@@ -32,7 +34,7 @@ const ModalController = () => {
 
   if (!findModal) return null;
 
-  const { title, size, component } = findModal;
+  const { title, size, overlayClose, component: Component } = findModal;
 
   const handleOverlayClick = () => {
     closeModal();
@@ -41,14 +43,14 @@ const ModalController = () => {
   return (
     <div
       className="flex justify-center items-center fixed inset-0 bg-black bg-opacity-50 z-20"
-      onClick={handleOverlayClick}
+      onClick={overlayClose ? handleOverlayClick : undefined}
     >
       <div
         className="relative"
         onClick={(e) => e.stopPropagation()}
       >
         <Modal title={title} size={size} closeModal={closeModal}>
-          {component}
+          <Component {...props} />
         </Modal>
       </div>
     </div>

--- a/src/components/common/modal/modal-contents/ModalTemp.tsx
+++ b/src/components/common/modal/modal-contents/ModalTemp.tsx
@@ -1,8 +1,23 @@
-import React from 'react'
+import React, { ReactNode } from 'react'
 
-const ModalTemp = () => {
+export interface ModalTempProps {
+  name : string;
+  age : number;
+  object : {
+    obj1 : boolean,
+    obj2 : string
+  },
+  component : ReactNode
+}
+const ModalTemp = ({name, age, object, component} : ModalTempProps) => {
   return (
-    <div>ModalTemp</div>
+    <div>
+      {name}
+      {age}
+      {object.obj1}
+      {object.obj2}
+      {component}
+    </div>
   )
 }
 

--- a/src/stores/modalStore.ts
+++ b/src/stores/modalStore.ts
@@ -4,17 +4,19 @@ import { devtools } from "zustand/middleware";
 
 interface IModalStore {
   isOpen: boolean;
-  modalType : TmodalType
-  openModal: (modalType : TmodalType) => void;
+  modalType: TmodalType;
+  props?: object | null;
+  openModal: <T extends object>(modalType: TmodalType, props?: T) => void;
   closeModal: () => void;
 }
 
 export const useModalStore = create<IModalStore>()(
   devtools((set) => ({
     isOpen: false,
-    modalType : null,
-    openModal: (modalType : TmodalType = null) => 
-      set({ isOpen: true, modalType: modalType }),
-    closeModal: () => set({ isOpen: false, modalType: null})
+    modalType: null,
+    props: null,
+    openModal: <T extends object>(modalType: TmodalType, props?: T) =>
+      set({ isOpen: true, modalType, props: props || null }),
+    closeModal: () => set({ isOpen: false, modalType: null, props: null }),
   }))
 );


### PR DESCRIPTION
## 🚩 관련 이슈
- close #40 

## 📋 변경 사항 (Changes)
> 변경 사항을 간략하게 설명해주세요. 

모달 생성시 생성 컴포넌트 인자로 데이터 전달할 수 있도록 추가
오버레이 클릭 동작 제어 변수 추가

- [x] A 기능 구현
- [ ] B 버그 수정

<img width="218" alt="모달-객체입력인자" src="https://github.com/user-attachments/assets/43feb7d4-b240-4ea6-9ddb-98ac05c8483a">
<br/>
모달 객체 생성 인자로 overlayClose를 추가하였습니다. 해당 변수의 boolean 값으로 오버레이 핸들러가 제어됩니다.
리뷰 생성, 스팟 생성 모달에서 오버레이 닫힘이 적용되면 많이 불편할 것 같아 추가했습니다. 필요 없다면 제거하겠습니다.
<img width="401" alt="모달-생성" src="https://github.com/user-attachments/assets/380a8017-f118-49b7-bfa2-e5418ee3ae7d"><br/>
모달 생성시 props를 입력 받을 수 있도록 옵션인자를 추가하였습니다. openModal로 모달을 호출할 떄, 
**openModal<모달에 넣을 Props 타입>("컨트롤러에 사전에 지정한 모달 타입","모달에 넣을 Props")** 로 활용하시면 됩니다.

## 📸 결과물 스크린샷 (Screenshots) (선택사항)
> 변경 사항에 대한 스크린샷을 첨부해주세요.
<img width="439" alt="모달사진" src="https://github.com/user-attachments/assets/55d0f03d-78c6-4772-8d4d-62d5d8b72422">

