### PR TITLE
Fix: 셀렉션 이미지 UI 깨짐 고침

### DIFF
--- a/src/components/selection-create/SelectionCreateForm.tsx
+++ b/src/components/selection-create/SelectionCreateForm.tsx
@@ -331,15 +331,24 @@ const SelectionCreateForm = () => {
           <div className="flex items-start gap-6 py-6">
             <div className="flex items-start grow">
               <label htmlFor="title" className="w-1/4 text-medium font-bold">셀렉션 썸네일 등록</label>
-              <button className="relative border border-solid border-grey2 w-3/4 h-[190px] rounded-[8px] bg-white flex flex-col items-center justify-center">
+              <button className="relative border border-solid border-grey2 w-3/4 h-[190px] rounded-[8px] bg-white flex flex-col items-center justify-center overflow-hidden">
                 {thumbnailImage ? (
                   <img 
-                    src={thumbnailImage instanceof File ? URL.createObjectURL(thumbnailImage) : thumbnailImage} 
-                    className="w-auto h-full object-cover" 
+                    src={
+                      thumbnailImage instanceof File ? 
+                        URL.createObjectURL(thumbnailImage) : 
+                        thumbnailImage
+                    } 
+                    className="w-auto h-full object-cover absolute"
                     alt="thumbnail"
                   />
                 ) : (
-                  <Image src="/icons/photo_camera_7C7C7C.svg" width={56} height={56} alt="upload_photo"/>
+                  <Image 
+                    src="/icons/photo_camera_7C7C7C.svg" 
+                    width={56} 
+                    height={56} 
+                    alt="upload_photo"
+                  />
                 )}
                 <input
                   type='file'


### PR DESCRIPTION
## 🚩 관련 이슈

- close #72 

## 📋 변경 사항 (Changes)
> 변경 사항을 간략하게 설명해주세요. 
> Ex) 이슈 #1 에 대한 해결, 새로운 기능 추가, 버그 수정 등

- [ ] A 기능 구현
- [x] B 버그 수정

## ✅ 체크리스트 (Check List)
> 변경 사항을 리뷰할 때 확인해야 할 사항들을 체크해주세요.
- [x] 코드 스타일 가이드 준수
- [ ] 코멘트 추가
- [ ] 테스트 코드 작성
- [ ] 머지 전 머지 충돌 해결

## 🔔 참고 사항 (References)
> 참고할 이슈, PR, 문서 등이 있다면 링크를 첨부해주세요.
- #72 셀렉션 이미지 UI 깨짐
  - CSS의 position 애트리뷰트를 absolute으로 사용하여 이미지 깨짐 방지

## 📸 결과물 스크린샷 (Screenshots) (선택사항)
> 변경 사항에 대한 스크린샷을 첨부해주세요.
### 고치기 이전 UI
<img width="975" alt="Screenshot 2024-08-07 at 23 01 50" src="https://github.com/user-attachments/assets/7a62aef6-28bf-40ef-8f9c-fba412726e25">

### 고친 이후 UI
<img width="975" alt="Screenshot 2024-08-07 at 23 28 13" src="https://github.com/user-attachments/assets/214154af-01dc-486c-b676-652abe0d31fe">

## 💬 리뷰어에게 전달할 내용 (Additional Context)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.
- 
