### PR TITLE
Remove/#297 계정 관리 삭제, 해시태그 유효성 검사 수정

### DIFF
--- a/src/app/api/selections/popular/route.ts
+++ b/src/app/api/selections/popular/route.ts
@@ -9,7 +9,6 @@ export const dynamic = "force-dynamic";
 export async function GET(
   req: NextRequest
 ): Promise<NextResponse<IRowCardProps[] | ErrorResponse>> {
-  // Todo : 쿠키로 userId를 받고, 로그인 되면 booked 값 설정
   try {
     const popularSelections = await getPopularSelection();
     const MappingResults: IRowCardProps[] = popularSelections.map((item) => ({
@@ -20,7 +19,7 @@ export async function GET(
       description: item.slt_description,
       userName: item.user_nickname,
       userImage: item.user_img,
-      booked: false, // 추가 로직 필요,
+      booked: false,
       selectionId: item.slt_id
     }));
     return NextResponse.json(MappingResults);

--- a/src/app/api/selections/search/route.ts
+++ b/src/app/api/selections/search/route.ts
@@ -105,8 +105,8 @@ const getSearchResultValidator = (
   }
 
   for (const tag of tags) {
-    if (tag.length > 10) {
-      return { error: "해시태그는 10글자 이내여야 합니다." };
+    if (tag.length > 40) {
+      return { error: "해시태그는 40글자 이내여야 합니다." };
     }
   }
 

--- a/src/app/api/users/[userId]/hashtag/route.ts
+++ b/src/app/api/users/[userId]/hashtag/route.ts
@@ -57,8 +57,8 @@ const postUserHashtagValidator = async (userId : string, hashtag : string): Prom
     if (!hashtag) {
         return NextResponse.json({ error: "유효하지 않은 데이터입니다." }, { status: 400 });
     }
-    if(hashtag.length > 10) {
-        return NextResponse.json({ error: "10자 이내로 입력해주세요" }, { status: 400 });
+    if(hashtag.length > 40) {
+        return NextResponse.json({ error: "40자 이내로 입력해주세요" }, { status: 400 });
     }
     // Todo: 쿠키로 받은 데이터와 ID가 일치하는지 유효성 추가
     return null;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,7 +13,7 @@ export const dynamic = "force-dynamic";
 
 export default async function Home() {
   try {
-    const popularSelections = await fetchHandler("api/selections/popular", 1);
+    const popularSelections = await fetchHandler("api/selections/popular", 0);
     return (
       <Suspense fallback={<PageLoading />}>
         <main className="w-[1086px] bg-grey0 border border-solid border-grey2 m-auto pt-10 flex flex-col gap-10 box-border h-auto">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -25,7 +25,7 @@ export default async function Home() {
       </Suspense>
     );
   } catch (error) {
-    console.log(error)
+    console.error(error)
     return <PageError/>
   }
 }

--- a/src/app/user/[userId]/account/page.tsx
+++ b/src/app/user/[userId]/account/page.tsx
@@ -1,9 +1,0 @@
-import React from 'react'
-
-const UserAccountPage = () => {
-  return (
-    <div>page</div>
-  )
-}
-
-export default UserAccountPage

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -46,8 +46,8 @@ const Header = () => {
       setTagValue("");
       return false;
     }
-    if (addTag.length > 10) {
-      toast.error("10글자 이내로 작성해주세요");
+    if (addTag.length > 40) {
+      toast.error("40글자 이내로 작성해주세요");
       setTagValue("");
       return false;
     }

--- a/src/components/user/my/UserNavigation.tsx
+++ b/src/components/user/my/UserNavigation.tsx
@@ -6,9 +6,7 @@ import { usePathname } from 'next/navigation';
 
 const userNavigationListData = [
   { name: '셀렉션 관리', url: '/' },
-  { name: '리뷰 관리', url: '/review' },
-  { name: '계정 관리', url: '/account' }
-];
+  { name: '리뷰 관리', url: '/review' }];
 
 const UserNavigation: React.FC = () => {
   const currentPath = usePathname();

--- a/src/hooks/mutations/useBookMarks.ts
+++ b/src/hooks/mutations/useBookMarks.ts
@@ -285,7 +285,6 @@ const updateUserSelectionData = (
   >(userSelectionQueryKey);
 
   if (previousUserSelection) {
-    console.log
     const updatedSearchResult = {
       ...previousUserSelection,
       data: previousUserSelection.data.map((selection) =>

--- a/src/hooks/useSearchAutoComplete.ts
+++ b/src/hooks/useSearchAutoComplete.ts
@@ -29,8 +29,8 @@ const useSearchAutoComplete = () => {
         toast.error("해시태그를 입력해주세요.");
         return false;
     }
-    if (tag.length > 10) {
-        toast.error("10글자 이내로 작성해주세요");
+    if (tag.length > 40) {
+        toast.error("40글자 이내로 작성해주세요");
         return false;
     }
     if (Array.isArray(hashtags) && hashtags.length >= 8) {


### PR DESCRIPTION
## 🚩 관련 이슈
- close #294 

## 📋 변경 사항 (Changes)
1. 계정관리 탭을 삭제하였습니다.
2. 태그 검색, 생성 유효성 검사를 10자 제한에서 40자 제한으로 수정하였습니다.
3. 인기 셀렉션 로직을 수정하였습니다. private,delete 셀렉션을 우선 배제한 후 데이터를 받도록 하였습니다

- [x] B 버그 수정
